### PR TITLE
clean out version from composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,6 @@
   "description": "Yandex Metrika API Library",
   "homepage": "https://github.com/axp-dev/ya-metrika",
   "keywords": ["yandex", "metrika", "api"],
-  "version": "2.2.0",
   "license": "MIT",
   "authors": [
     {


### PR DESCRIPTION
reason:  repo already uses tags